### PR TITLE
chore(overrides): seed Core30 30d trend for P1 fallback

### DIFF
--- a/data/overrides/USLAX/trend.json
+++ b/data/overrides/USLAX/trend.json
@@ -1,0 +1,217 @@
+{
+  "unlocode": "USLAX",
+  "points": [
+    {
+      "date": "2025-07-29",
+      "vessels": 83,
+      "avg_wait_hours": 31.0,
+      "congestion_score": 57,
+      "src": "demo"
+    },
+    {
+      "date": "2025-07-30",
+      "vessels": 86,
+      "avg_wait_hours": 27.0,
+      "congestion_score": 53,
+      "src": "demo"
+    },
+    {
+      "date": "2025-07-31",
+      "vessels": 89,
+      "avg_wait_hours": 32.0,
+      "congestion_score": 58,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-01",
+      "vessels": 92,
+      "avg_wait_hours": 28.0,
+      "congestion_score": 54,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-02",
+      "vessels": 95,
+      "avg_wait_hours": 33.0,
+      "congestion_score": 59,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-03",
+      "vessels": 98,
+      "avg_wait_hours": 29.0,
+      "congestion_score": 55,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-04",
+      "vessels": 101,
+      "avg_wait_hours": 34.0,
+      "congestion_score": 60,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-05",
+      "vessels": 104,
+      "avg_wait_hours": 30.0,
+      "congestion_score": 56,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-06",
+      "vessels": 107,
+      "avg_wait_hours": 26.0,
+      "congestion_score": 52,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-07",
+      "vessels": 110,
+      "avg_wait_hours": 31.0,
+      "congestion_score": 57,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-08",
+      "vessels": 113,
+      "avg_wait_hours": 27.0,
+      "congestion_score": 53,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-09",
+      "vessels": 116,
+      "avg_wait_hours": 32.0,
+      "congestion_score": 58,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-10",
+      "vessels": 119,
+      "avg_wait_hours": 28.0,
+      "congestion_score": 54,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-11",
+      "vessels": 82,
+      "avg_wait_hours": 33.0,
+      "congestion_score": 59,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-12",
+      "vessels": 85,
+      "avg_wait_hours": 29.0,
+      "congestion_score": 55,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-13",
+      "vessels": 88,
+      "avg_wait_hours": 37.0,
+      "congestion_score": 63,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-14",
+      "vessels": 91,
+      "avg_wait_hours": 33.0,
+      "congestion_score": 59,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-15",
+      "vessels": 94,
+      "avg_wait_hours": 29.0,
+      "congestion_score": 55,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-16",
+      "vessels": 97,
+      "avg_wait_hours": 34.0,
+      "congestion_score": 60,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-17",
+      "vessels": 100,
+      "avg_wait_hours": 30.0,
+      "congestion_score": 56,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-18",
+      "vessels": 103,
+      "avg_wait_hours": 35.0,
+      "congestion_score": 61,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-19",
+      "vessels": 106,
+      "avg_wait_hours": 31.0,
+      "congestion_score": 57,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-20",
+      "vessels": 109,
+      "avg_wait_hours": 36.0,
+      "congestion_score": 62,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-21",
+      "vessels": 112,
+      "avg_wait_hours": 32.0,
+      "congestion_score": 58,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-22",
+      "vessels": 115,
+      "avg_wait_hours": 37.0,
+      "congestion_score": 63,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-23",
+      "vessels": 118,
+      "avg_wait_hours": 33.0,
+      "congestion_score": 59,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-24",
+      "vessels": 81,
+      "avg_wait_hours": 29.0,
+      "congestion_score": 55,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-25",
+      "vessels": 84,
+      "avg_wait_hours": 34.0,
+      "congestion_score": 60,
+      "src": "demo"
+    },
+    {
+      "date": "2025-08-26",
+      "vessels": 87,
+      "avg_wait_hours": 30.0,
+      "congestion_score": 56,
+      "src": "demo",
+      "as_of": "2025-08-27T07:16:49.184985+00:00"
+    },
+    {
+      "date": "2025-08-27",
+      "vessels": 87,
+      "avg_wait_hours": 30.0,
+      "congestion_score": 56,
+      "src": "nowcast",
+      "as_of": "2025-08-27T10:40:02.903890+00:00"
+    }
+  ]
+}


### PR DESCRIPTION
	Title：chore(overrides): seed Core30 30d trend for P1 fallback
	•	Description（可贴验收清单）：Core30 30d overrides；/trend 30d 无空洞；CSV strong ETag 保持；snapshot 由 override 推导。